### PR TITLE
Add shutdown_timeout as environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The watchdog can be configured through environmental variables. You must always 
 | `suppress_lock`        | The watchdog will attempt to write a lockfile to /tmp/ for swarm healthchecks - set this to true to disable behaviour. |
 | `exec_timeout`         | Hard timeout for process exec'd for each incoming request (in seconds). Disabled if set to 0 |
 | `write_debug`          | Write all output, error messages, and additional information to the logs. Default is false |
+| `shutdown_timeout`     | Graceful shutdowns will last a least twice this number (in seconds). See section: *Graceful shutdowns* for more detail. Defaults to `write_timeout` |
 | `combine_output`       | True by default - combines stdout/stderr in function response, when set to false `stderr` is written to the container logs and stdout is used for function response |
 | `max_inflight`         | Limit the maximum number of requests in flight |
 
@@ -120,11 +121,11 @@ This re-write is mainly structural for on-going maintenance. It will be a drop-i
 
 The watchdog is capable of working with health-checks to provide a graceful shutdown.
 
-When a `SIGTERM` signal is detected within the watchdog process a Go routine will remove the `/tmp/.lock` file and mark the HTTP health-check as unhealthy and return HTTP 503. The code will then wait for the duration specified in `write_timeout`. During this window the container-orchestrator's health-check must run and complete.
+When a `SIGTERM` signal is detected within the watchdog process a Go routine will remove the `/tmp/.lock` file and mark the HTTP health-check as unhealthy and return HTTP 503. The code will then wait for the duration specified in `shutdown_timeout`. During this window the container-orchestrator's health-check must run and complete.
 
 Now the orchestrator will mark this replica as unhealthy and remove it from the pool of valid HTTP endpoints.
 
-Now we will stop accepting new connections and wait for the value defined in `write_timeout` before finally allowing the process to exit.
+Now we will stop accepting new connections and wait for the value defined in `shutdown_timeout` before finally allowing the process to exit.
 
 ### Working with HTTP headers
 

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 
 	go metricsServer.Serve(cancel)
 
-	shutdownTimeout := config.writeTimeout
+	shutdownTimeout := config.shutdownTimeout
 	listenUntilShutdown(shutdownTimeout, s, config.suppressLock)
 }
 

--- a/readconfig.go
+++ b/readconfig.go
@@ -66,6 +66,7 @@ func (ReadConfig) Read(hasEnv HasEnv) WatchdogConfig {
 
 	cfg.readTimeout = parseIntOrDurationValue(hasEnv.Getenv("read_timeout"), time.Second*5)
 	cfg.writeTimeout = parseIntOrDurationValue(hasEnv.Getenv("write_timeout"), time.Second*5)
+	cfg.shutdownTimeout = parseIntOrDurationValue(hasEnv.Getenv("shutdown_timeout"), cfg.writeTimeout)
 
 	cfg.execTimeout = parseIntOrDurationValue(hasEnv.Getenv("exec_timeout"), time.Second*0)
 	cfg.port = parseIntValue(hasEnv.Getenv("port"), 8080)
@@ -111,6 +112,11 @@ type WatchdogConfig struct {
 
 	// duration until the faasProcess will be killed
 	execTimeout time.Duration
+
+	// when SIGTERM is sent the server will wait `shutdownTimeout` before
+	// closing off connections and a futher `shutdownTimeout` before exiting
+	// defaults to `writeTimeout` if not specified
+	shutdownTimeout time.Duration
 
 	// writeDebug write console stdout statements to the container
 	writeDebug bool


### PR DESCRIPTION
Add shutdown timeout as environment variable. This is to specify a shutdown timeout different from `write_timeout` in case that is desired, which is useful if for example write timeout is 15min and we want the shutdown timeout to be 5 seconds if the function pod is idle and receives a termination signal.